### PR TITLE
Indexes on single attribute foreign keys

### DIFF
--- a/test/__snapshots__/integration.spec.js.snap
+++ b/test/__snapshots__/integration.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`postgres should check the generated indexes: indexList 1`] = `
+Array [
+  "PK_865a0f2e22c140d261b1df80eb1",
+  "board_created_by_key",
+  "board_is_private_key",
+  "board_name_key",
+  "board_owner_key",
+  "board_updated_by_key",
+]
+`;

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -8,6 +8,7 @@ import { counts } from './testSetGenerator';
 import { Profile } from './models/Profile';
 import { Board } from './models/Board';
 import { BoardMember } from './models/BoardMember';
+import { StorageTypePostgres } from '../src/StorageTypePostgres';
 
 describe('postgres', () => {
   it('test data imported correctly', async () => {
@@ -19,5 +20,19 @@ describe('postgres', () => {
 
     const memberCount = await count(BoardMember, {}, asAdmin());
     expect(memberCount).toEqual(counts.joinCount + counts.inviteCount);
+  });
+
+  it('should check the generated indexes', async () => {
+    const storageInstance = StorageTypePostgres.getStorageInstance();
+    const manager = storageInstance.manager;
+    const indexes = await manager.query(`
+      select indexname
+      from pg_indexes
+      where tablename = 'board'
+      order by indexname
+    `);
+
+    const indexList = indexes.map(i => i.indexname);
+    expect(indexList).toMatchSnapshot('indexList');
   });
 });


### PR DESCRIPTION
Automatically adding indices on all foreign keys (single key) to help the data loader along the ChildrenByParent edge connections